### PR TITLE
Add event based hook to calculate doom (#550)

### DIFF
--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyMap_HUD.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/UIStrategyMap_HUD.uc
@@ -128,12 +128,15 @@ simulated function UpdateMissingPersons()
 simulated function UpdateData()
 {
 	local int i;
+	local int CurrentDoom;
+	local int MaxDoom;
 	local XComGameState_HeadquartersAlien AlienHQ;
 	local XComGameState_HeadquartersResistance ResHQ;
 	local XComGameState NewGameState;
 	local bool bPlayedSound;
 	
 	bPlayedSound = false;
+	`log("UpdateData() Start");
 
 	if(Movie.Stack.GetCurrentClass() != class'UIStrategyMap') return;
 
@@ -214,10 +217,15 @@ simulated function UpdateData()
 		}
 
 		MC.BeginFunctionOp("UpdateDoomMeter");
+		//Issue 550
+		//Chaching doom values below as a change to GetCurrentDoom activates an event and if that function is called
+		//on each iteration of the loop it could cause unneded work to be done by the listener.
+		MaxDoom = AlienHQ.GetMaxDoom();	
+		CurrentDoom = AlienHQ.GetCurrentDoom();
 
-		for (i = 0; i < AlienHQ.GetMaxDoom(); ++i)
+		for (i = 0; i < MaxDoom; ++i)
 		{
-			if( i < AlienHQ.GetCurrentDoom() )
+			if(i < CurrentDoom)
 			{
 				if(i >= CachedDoom)
 				{
@@ -230,7 +238,6 @@ simulated function UpdateData()
 
 						bPlayedSound = true;
 					}
-					
 					MC.QueueNumber(2); //New blocks are 2
 				}
 				else
@@ -247,7 +254,6 @@ simulated function UpdateData()
 						`XSTRATEGYSOUNDMGR.PlaySoundEvent("Geoscape_DoomDecrease");
 						bPlayedSound = true;
 					}
-					
 					MC.QueueNumber(3); // Blocks to remove
 				}
 				else

--- a/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersAlien.uc
+++ b/X2WOTCCommunityHighlander/Src/XComGame/Classes/XComGameState_HeadquartersAlien.uc
@@ -493,10 +493,27 @@ function int GetCurrentDoom(optional bool bIgnorePending = false)
 	local XComGameStateHistory History;
 	local XComGameState_MissionSite MissionState;
 	local int TotalDoom;
+	//#550 - Tuple to send to triggered event.
+	local XComLWTuple Tuple;
 
 	TotalDoom = Doom;
 	History = `XCOMHISTORY;
-	
+
+	//#550 -  set up Tuple for event use.
+	Tuple = new class'XComLWTuple';
+	Tuple.Id = 'GetCurrentDoom';
+	Tuple.Data.Add(3);
+	Tuple.Data[0].kind = XComLWTVInt;
+	Tuple.Data[0].i = 0;
+	Tuple.Data[1].kind = XComLWTVObject;
+	Tuple.Data[1].o = self;
+	Tuple.Data[2].kind = XComLWTVBool;
+	Tuple.Data[2].b = bIgnorePending;
+
+	//#550 - Trigger event that calcuilates current doom of unrevaled missions.
+	`XEVENTMGR.TriggerEvent('AddDoomModifier', Tuple);
+	TotalDoom += Tuple.Data[0].i;
+
 	foreach History.IterateByClassType(class'XComGameState_MissionSite', MissionState)
 	{
 		if(MissionState.Available)


### PR DESCRIPTION
This change is add an event based hook to calcualte doom for any mods
(like LW2) that have missions that generate doom that could potentially
be not revealed causing doom generation updates to no be displayed
properly.